### PR TITLE
Disable caching for fetch() calls, clarify documentations, fix stylesheets insertion, fix mobile detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,16 @@ WWPass.authInit({
 </script>
 ```
 
+## authInit options
+ - `qrcode`: DOM element or query selector for authentication QRCode
+ - `passkey`: *OPTIONAL* DOM element or query selector that holds button for hardware PassKey authentication. If the element is empty, default "Authenticate with PassKey" button will be rendered.
+ - `ticketURL`: URL to request WWPass ticket for authentication. On request to this URL the server should get new ticket via WWPass server API and return json object with ticket and it's ttl in seconds ex.: `{"ticket": "WWPass%20Developers:81f7ba34f27e9707787fd73d43463a3d4b9a0603@p-sp-02-20:16033", "ttl": 600}`
+ - `callbackURL`: after successful WWPass authentication the user will be redirected to this URL. Following parameters will be appended to the URL:
+    - `wwp_version`: current version of the protocol. For this library it's always `2`
+    - `wwp_ticket`: ticket used for authentication
+    - `wwp_status` and `wwp_reason`: always `200`, `"OK"` for successful authentications
+ - `ppx`: *OPTIONAL* Alternative prefix for `callbackURL` parameters. Defaults to `wwp_`
+
 ## Support
 
 If you have any questions, contact us support@wwpass.com.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "wwpass-frontend",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3425,8 +3425,7 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -3447,14 +3446,12 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -3469,20 +3466,17 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -3599,8 +3593,7 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "ini": {
               "version": "1.3.5",
@@ -3612,7 +3605,6 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -3627,7 +3619,6 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -3635,14 +3626,12 @@
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -3661,7 +3650,6 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -3742,8 +3730,7 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -3755,7 +3742,6 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -3841,8 +3827,7 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -3878,7 +3863,6 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -3898,7 +3882,6 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -3942,14 +3925,12 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "yallist": {
               "version": "3.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -8868,9 +8849,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "version": "4.17.14",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
+      "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==",
       "dev": true
     },
     "lodash.cond": {
@@ -9152,9 +9133,9 @@
       }
     },
     "mixin-deep": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
-      "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+      "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
       "dev": true,
       "requires": {
         "for-in": "^1.0.2",
@@ -13073,9 +13054,9 @@
       "dev": true
     },
     "set-value": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
-      "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+      "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
       "dev": true,
       "requires": {
         "extend-shallow": "^2.0.1",
@@ -14330,38 +14311,15 @@
       "dev": true
     },
     "union-value": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
-      "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+      "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
       "dev": true,
       "requires": {
         "arr-union": "^3.1.0",
         "get-value": "^2.0.6",
         "is-extendable": "^0.1.1",
-        "set-value": "^0.4.3"
-      },
-      "dependencies": {
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "dev": true,
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        },
-        "set-value": {
-          "version": "0.4.3",
-          "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
-          "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
-          "dev": true,
-          "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-extendable": "^0.1.1",
-            "is-plain-object": "^2.0.1",
-            "to-object-path": "^0.3.0"
-          }
-        }
+        "set-value": "^2.0.1"
       }
     },
     "uniq": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wwpass-frontend",
   "license": "MIT",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Frontend WWPass JavaScript Library",
   "scripts": {
     "eslint": "eslint src/",

--- a/src/auth.js
+++ b/src/auth.js
@@ -1,6 +1,12 @@
 import { wwpassQRCodeAuth } from './qrcode/auth';
 import { wwpassPasskeyAuth } from './passkey/auth';
 
+const absolutePath = (href) => {
+  const link = document.createElement('a');
+  link.href = href;
+  return link.href;
+};
+
 const authInit = (initialOptions) => {
   const defaultOptions = {
     ticketURL: '',
@@ -12,6 +18,7 @@ const authInit = (initialOptions) => {
   };
 
   const options = Object.assign({}, defaultOptions, initialOptions);
+  options.callbackURL = absolutePath(options.callbackURL);
   options.passkeyButton = (typeof options.passkey === 'string') ? document.querySelector(options.passkey) : options.passkey;
   options.qrcode = (typeof options.qrcode === 'string') ? document.querySelector(options.qrcode) : options.qrcode;
 

--- a/src/getticket.js
+++ b/src/getticket.js
@@ -2,7 +2,7 @@ import { getWebSocketResult } from './qrcode/wwpass.websocket';
 import { getClientNonce } from './nonce';
 import { isClientKeyTicket } from './ticket';
 
-const getTicket = url => fetch(url).then((response) => {
+const getTicket = url => fetch(url, { cache: 'no-store' }).then((response) => {
   if (!response.ok) {
     throw Error(`Error fetching ticket from "${url}": ${response.statusText}`);
   }
@@ -16,7 +16,7 @@ const getTicket = url => fetch(url).then((response) => {
   The functions ultimately resolves to:
   {"ticket": "<new_ticket>", "ttl": <new_ticket_ttl>}
 */
-const updateTicket = url => fetch(url).then((response) => {
+const updateTicket = url => fetch(url, { cache: 'no-store' }).then((response) => {
   if (!response.ok) {
     throw Error(`Error updating ticket from "${url}": ${response.statusText}`);
   }

--- a/src/getticket.js
+++ b/src/getticket.js
@@ -2,7 +2,9 @@ import { getWebSocketResult } from './qrcode/wwpass.websocket';
 import { getClientNonce } from './nonce';
 import { isClientKeyTicket } from './ticket';
 
-const getTicket = url => fetch(url, { cache: 'no-store' }).then((response) => {
+const noCacheHeaders = { pragma: 'no-cache', 'cache-control': 'no-cache' };
+
+const getTicket = url => fetch(url, { cache: 'no-store', headers: noCacheHeaders }).then((response) => {
   if (!response.ok) {
     throw Error(`Error fetching ticket from "${url}": ${response.statusText}`);
   }
@@ -16,7 +18,7 @@ const getTicket = url => fetch(url, { cache: 'no-store' }).then((response) => {
   The functions ultimately resolves to:
   {"ticket": "<new_ticket>", "ttl": <new_ticket_ttl>}
 */
-const updateTicket = url => fetch(url, { cache: 'no-store' }).then((response) => {
+const updateTicket = url => fetch(url, { cache: 'no-store', headers: noCacheHeaders }).then((response) => {
   if (!response.ok) {
     throw Error(`Error updating ticket from "${url}": ${response.statusText}`);
   }

--- a/src/qrcode/ui.js
+++ b/src/qrcode/ui.js
@@ -25,7 +25,7 @@ const setLoader = (element, styles) => {
   <div class="${loaderClass}_blk"></div>`;
   if (!haveStyleSheet) {
     const style = document.createElement('style');
-    style.innerText = `@keyframes ${styles.prefix || 'wwp_'}pulse {
+    style.innerHTML = `@keyframes ${styles.prefix || 'wwp_'}pulse {
       0%   { opacity: 1; }
       100% { opacity: 0; }
     }
@@ -48,8 +48,7 @@ const setLoader = (element, styles) => {
     }
     .${loaderClass}_delay {
       animation-delay: 0.75s;
-    }
-    </style>`;
+    }`;
     document.getElementsByTagName('head')[0].appendChild(style);
     haveStyleSheet = true;
   }

--- a/src/qrcode/ui.js
+++ b/src/qrcode/ui.js
@@ -4,9 +4,10 @@ import WWPassError from '../error';
 import { WWPASS_STATUS } from '../passkey/constants';
 
 
-const isMobile = () => navigator &&
-    'userAgent' in navigator &&
-    navigator.userAgent.match(/iPhone|iPod|iPad|Android/i);
+const isMobile = () => navigator && (
+      ('userAgent' in navigator && navigator.userAgent.match(/iPhone|iPod|iPad|Android/i)) ||
+      (navigator.maxTouchPoints > 1)
+    ) && !window.MSStream;
 
 const removeLoader = (element) => {
   while (element.firstChild) {

--- a/test/qrcode.test.js
+++ b/test/qrcode.test.js
@@ -105,7 +105,7 @@ describe('wwpassQRcodeAuth', () => {
       qrcode: document.getElementById('qrcode')
     };
     return wwpassQRCodeAuth(options).then((result) => {
-      expect(global.fetch).toBeCalledWith('https://ticket.url/', {"cache": "no-store"});
+      expect(global.fetch).toBeCalledWith('https://ticket.url/', {"cache": "no-store", "headers": {"cache-control": "no-cache", "pragma": "no-cache"}});
       expect(result).toEqual({
         ppx: 'wwp_',
         version: 2,
@@ -136,7 +136,7 @@ describe('wwpassQRcodeAuth', () => {
     };
     expect.assertions(2);
     return wwpassQRCodeAuth(options).catch((result) => {
-      expect(global.fetch).toBeCalledWith('https://ticket.url/', {"cache": "no-store"});
+      expect(global.fetch).toBeCalledWith('https://ticket.url/', {"cache": "no-store", "headers": {"cache-control": "no-cache", "pragma": "no-cache"}});
       expect(result).toEqual({
         ppx: 'wwp_',
         version: 2,
@@ -167,7 +167,7 @@ describe('wwpassQRcodeAuth', () => {
     };
     expect.assertions(2);
     return wwpassQRCodeAuth(options).then(jest.fa).catch((result) => {
-      expect(global.fetch).toBeCalledWith('https://ticket.url/', {"cache": "no-store"});
+      expect(global.fetch).toBeCalledWith('https://ticket.url/', {"cache": "no-store", "headers": {"cache-control": "no-cache", "pragma": "no-cache"}});
       expect(result).toEqual({
         ppx: 'wwp_',
         version: 2,
@@ -205,7 +205,7 @@ describe('wwpassQRcodeAuth', () => {
 
     global.fetch.mockClear(0);
     return wwpassQRCodeAuth(options).then((result) => {
-      expect(global.fetch).toBeCalledWith('https://ticket.url/', {"cache": "no-store"});
+      expect(global.fetch).toBeCalledWith('https://ticket.url/', {"cache": "no-store", "headers": {"cache-control": "no-cache", "pragma": "no-cache"}});
       expect(global.fetch).toHaveBeenCalledTimes(2);
       expect(result).toEqual({
         ppx: 'wwp_',

--- a/test/qrcode.test.js
+++ b/test/qrcode.test.js
@@ -105,7 +105,7 @@ describe('wwpassQRcodeAuth', () => {
       qrcode: document.getElementById('qrcode')
     };
     return wwpassQRCodeAuth(options).then((result) => {
-      expect(global.fetch).toBeCalledWith('https://ticket.url/');
+      expect(global.fetch).toBeCalledWith('https://ticket.url/', {"cache": "no-store"});
       expect(result).toEqual({
         ppx: 'wwp_',
         version: 2,
@@ -136,7 +136,7 @@ describe('wwpassQRcodeAuth', () => {
     };
     expect.assertions(2);
     return wwpassQRCodeAuth(options).catch((result) => {
-      expect(global.fetch).toBeCalledWith('https://ticket.url/');
+      expect(global.fetch).toBeCalledWith('https://ticket.url/', {"cache": "no-store"});
       expect(result).toEqual({
         ppx: 'wwp_',
         version: 2,
@@ -167,7 +167,7 @@ describe('wwpassQRcodeAuth', () => {
     };
     expect.assertions(2);
     return wwpassQRCodeAuth(options).then(jest.fa).catch((result) => {
-      expect(global.fetch).toBeCalledWith('https://ticket.url/');
+      expect(global.fetch).toBeCalledWith('https://ticket.url/', {"cache": "no-store"});
       expect(result).toEqual({
         ppx: 'wwp_',
         version: 2,
@@ -205,7 +205,7 @@ describe('wwpassQRcodeAuth', () => {
 
     global.fetch.mockClear(0);
     return wwpassQRCodeAuth(options).then((result) => {
-      expect(global.fetch).toBeCalledWith('https://ticket.url/');
+      expect(global.fetch).toBeCalledWith('https://ticket.url/', {"cache": "no-store"});
       expect(global.fetch).toHaveBeenCalledTimes(2);
       expect(result).toEqual({
         ppx: 'wwp_',


### PR DESCRIPTION
Fetch by default may use the cache, this is unacceptable as server
misconfiguration will lead to ticket reuse.
"cache: 'no-store'" was added to prevent any cache lookups there.

This PR also clarifies documentation for "authInit()" call and fixes problems with stylesheet insertion for qrcode UI.