### PR TITLE
added callback function as an option for Single Page Applications

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wwpass-frontend",
   "license": "MIT",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "description": "Frontend WWPass JavaScript Library",
   "scripts": {
     "eslint": "eslint src/",

--- a/src/auth.js
+++ b/src/auth.js
@@ -18,7 +18,9 @@ const authInit = (initialOptions) => {
   };
 
   const options = { ...defaultOptions, ...initialOptions };
-  options.callbackURL = absolutePath(options.callbackURL);
+  if(typeof(options.callbackURL) == 'string') {
+    options.callbackURL = absolutePath(options.callbackURL);
+  }
   options.passkeyButton = (typeof options.passkey === 'string') ? document.querySelector(options.passkey) : options.passkey;
   options.qrcode = (typeof options.qrcode === 'string') ? document.querySelector(options.qrcode) : options.qrcode;
 

--- a/src/navigation.js
+++ b/src/navigation.js
@@ -1,7 +1,11 @@
 import { getCallbackURL } from './urls';
 
 const navigateToCallback = (options) => {
-  window.location.href = getCallbackURL(options);
+  if (typeof(options.callbackURL) === 'function') {
+    options.callbackURL(getCallbackURL(options))
+  } else { // URL string
+    window.location.href = getCallbackURL(options);
+  }
 };
 
 export default navigateToCallback;

--- a/src/urls.js
+++ b/src/urls.js
@@ -11,7 +11,11 @@ const getCallbackURL = (initialOptions = {}) => {
 
   const options = { ...defaultOptions, ...initialOptions };
 
-  let url = options.callbackURL;
+  let url = '';
+  if(typeof(options.callbackURL) == 'string') {
+    url = options.callbackURL;
+  }
+
   const firstDelimiter = (url.indexOf('?') === -1) ? '?' : '&';
 
   url += `${firstDelimiter + encodeURIComponent(options.ppx)}version=${options.version}`;


### PR DESCRIPTION
Rationale: as of today, Callback URL forces page reload (window.location=), which is to be avoided in Single Page Applications and Electron apps 
Callback now may be a function; the module distinguishes callback mode by the type (string/function) of CallbackURL argument (the property name is preserved for backward compatibility). 

How to use:
- no changes for the existing code: solution is backward compatible
- for SPA, provide a callback function, as follows (ajax example):

  function loginCallback(str) {
    $.ajax({
      url: `${urlBase}loginSPA.php${str}`,
      type: 'GET',
      success: processResponce,
      .....
    });
  }


      WWPass.authInit({
        qrcode: '#qrcode',
        passkey: '#button--login',
        ticketURL: `${urlBase}getticket.php`,
        callbackURL: loginCallback,
      });
 
