### PR TITLE
Fix: Authentication on old ticket

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wwpass-frontend",
   "license": "MIT",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Frontend WWPass JavaScript Library",
   "scripts": {
     "eslint": "eslint src/",

--- a/src/qrcode/auth.js
+++ b/src/qrcode/auth.js
@@ -53,7 +53,8 @@ const tryQRCodeAuth = async (options) => {
         development: options.development,
         version: options.version,
         ppx: options.ppx,
-        spfewsAddress: options.spfewsAddress
+        spfewsAddress: options.spfewsAddress,
+        returnErrors: options.returnErrors
       })
     ]);
     clearQRCode(options.qrcode, options.qrcodeStyle);
@@ -73,7 +74,6 @@ const tryQRCodeAuth = async (options) => {
         reason: 'User clicked on QRCode'
       };
     }
-    navigateToCallback(result);
     return result;
   } catch (err) {
     if (!err.status) {

--- a/src/qrcode/wwpass.websocket.js
+++ b/src/qrcode/wwpass.websocket.js
@@ -1,4 +1,5 @@
 import { WWPASS_OK_MSG, WWPASS_STATUS } from '../passkey/constants';
+import navigateToCallback from '../navigation';
 
 const connectionPool = [];
 const closeConnectionPool = () => {
@@ -43,7 +44,7 @@ const getWebSocketResult = (initialOptions) => new Promise((resolve, reject) => 
   let ttl = null;
   const settle = (status, reason) => {
     if (status === 200) {
-      resolve({
+      const result = {
         ppx: options.ppx,
         version: options.version,
         status,
@@ -53,16 +54,22 @@ const getWebSocketResult = (initialOptions) => new Promise((resolve, reject) => 
         clientKey,
         originalTicket,
         ttl
-      });
+      };
+      navigateToCallback(result);
+      resolve(result);
     } else {
-      reject({
+      const err = {
         ppx: options.ppx,
         version: options.version,
         status,
         reason,
         ticket: options.ticket,
         callbackURL: options.callbackURL
-      });
+      };
+      if (status === WWPASS_STATUS.INTERNAL_ERROR || options.returnErrors) {
+        navigateToCallback(err);
+      }
+      reject(err);
     }
   };
   if (!('WebSocket' in window)) {

--- a/test/crypto.test.js
+++ b/test/crypto.test.js
@@ -25,6 +25,6 @@ test('encodeBase64ForURI', () => {
 
 test('saveBuffer and loadBuffer', () => {
     const testBuffer = "TestBUFFER";
-    saveBuffer(new Buffer(testBuffer));
+    saveBuffer(new Buffer.from(testBuffer));
     expect(loadBuffer()).toEqual(new ArrayBuffer(testBuffer));
 });


### PR DESCRIPTION
if ticket is about to change while authentication is running, websocket result for the previous ticket was ignored. This commit fixes it.