### PR TITLE
Fix clientKeyOnly option for websocket

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wwpass-frontend",
   "license": "MIT",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "description": "Frontend WWPass JavaScript Library",
   "scripts": {
     "eslint": "eslint src/",

--- a/src/qrcode/wwpass.websocket.js
+++ b/src/qrcode/wwpass.websocket.js
@@ -21,7 +21,8 @@ const applyDefaults = (initialOptions) => {
     log: () => {},
     development: false,
     spfewsAddress: 'wss://spfews.wwpass.com',
-    echo: undefined
+    echo: undefined,
+    clientKeyOnly: false
   };
   return { ...defaultOptions, ...initialOptions };
 };
@@ -55,7 +56,9 @@ const getWebSocketResult = (initialOptions) => new Promise((resolve, reject) => 
         originalTicket,
         ttl
       };
-      navigateToCallback(result);
+      if (!options.clientKeyOnly) {
+        navigateToCallback(result);
+      }
       resolve(result);
     } else {
       const err = {
@@ -66,7 +69,7 @@ const getWebSocketResult = (initialOptions) => new Promise((resolve, reject) => 
         ticket: options.ticket,
         callbackURL: options.callbackURL
       };
-      if (status === WWPASS_STATUS.INTERNAL_ERROR || options.returnErrors) {
+      if ((status === WWPASS_STATUS.INTERNAL_ERROR || options.returnErrors) && !options.clientKeyOnly) {
         navigateToCallback(err);
       }
       reject(err);


### PR DESCRIPTION
Fix: Do not navigate to callback in getWebsocketResult if clientKeyOnly option is set